### PR TITLE
Permission to ignore authentication and use cookie credentials

### DIFF
--- a/Session/APISession.php
+++ b/Session/APISession.php
@@ -86,7 +86,9 @@ final class APISession implements SessionInterface{
 				$this->token->save();
 			}
 		
-		} else if (isset($_COOKIE['apine_session'])) {
+		}
+		
+		if (isset($_COOKIE['apine_session'])) {
 
 			$session = new WebSession();
 			$data = $session->data();


### PR DESCRIPTION
When using Basic HTTP authentication on Web calls, following API calls fail to authenticate with the user because the basic authentication makes the session fails to see the cookie authentication. I fixed that by making these two separate conditions.